### PR TITLE
Close resp body when finished.

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -56,6 +56,7 @@ func (c *Client) SendMessage(msg *Message) error {
 
 	http.NewRequest("POST", c.Url, buf)
 	resp, err := http.Post(c.Url, "application/json", buf)
+	defer resp.Body.Close()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The response body wasn't being closed, resulting in too many open files descriptors in my application using logrus.

Thanks! 
John
