### PR TITLE
Bugfix: close the response body only if there was no error

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -57,10 +57,10 @@ func (c *Client) SendMessage(msg *Message) error {
 
 	http.NewRequest("POST", c.Url, buf)
 	resp, err := http.Post(c.Url, "application/json", buf)
-	defer resp.Body.Close()
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		t, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Currently, if there is an error and `Body` is nil, Go will panic with a nil pointer dereference. To mitigate this we should only ever close the body if there was no error.